### PR TITLE
Fix drawing in dark mode

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -75,7 +75,5 @@ label[for="ephemeral"] {
 @media (prefers-color-scheme: dark) {
   canvas {
     background-color: #000;
-    width: 100%;
-    height: 100%;
   }
 }


### PR DESCRIPTION
In dark mode, the canvas is assigned a `height` of `100%`. As a result, it will be assigned the height of the parent element of `100vh`, ignoring the height of the menu. The canvas will be larger than the actual viewport, and therefore the drawing will deviate the further down you move the pointer.

![Untitled](https://user-images.githubusercontent.com/6698344/114469694-ed8e1c00-9bed-11eb-8a8d-72f9fc342d13.gif)
